### PR TITLE
chore: update rancoud dependencies

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "rancoud/environment",
-            "version": "2.1.9",
+            "version": "2.1.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rancoud/Environment.git",
-                "reference": "44b75c131de89f77168b10bac86acebb9697023e"
+                "reference": "81d98ace065a952db6c79bdb05d0c81ddd941212"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rancoud/Environment/zipball/44b75c131de89f77168b10bac86acebb9697023e",
-                "reference": "44b75c131de89f77168b10bac86acebb9697023e",
+                "url": "https://api.github.com/repos/rancoud/Environment/zipball/81d98ace065a952db6c79bdb05d0c81ddd941212",
+                "reference": "81d98ace065a952db6c79bdb05d0c81ddd941212",
                 "shasum": ""
             },
             "require": {
@@ -48,22 +48,22 @@
             "description": "Environment package",
             "support": {
                 "issues": "https://github.com/rancoud/Environment/issues",
-                "source": "https://github.com/rancoud/Environment/tree/2.1.9"
+                "source": "https://github.com/rancoud/Environment/tree/2.1.10"
             },
-            "time": "2024-01-20T17:59:02+00:00"
+            "time": "2024-03-03T20:27:54+00:00"
         },
         {
             "name": "rancoud/http",
-            "version": "3.2.0",
+            "version": "3.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rancoud/Http.git",
-                "reference": "c3c5a3703247f829652603564f03f50fb02c150b"
+                "reference": "ea5e0882533da98fb051fa187fedaa396f31da75"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rancoud/Http/zipball/c3c5a3703247f829652603564f03f50fb02c150b",
-                "reference": "c3c5a3703247f829652603564f03f50fb02c150b",
+                "url": "https://api.github.com/repos/rancoud/Http/zipball/ea5e0882533da98fb051fa187fedaa396f31da75",
+                "reference": "ea5e0882533da98fb051fa187fedaa396f31da75",
                 "shasum": ""
             },
             "require": {
@@ -101,22 +101,22 @@
             "description": "Http package",
             "support": {
                 "issues": "https://github.com/rancoud/Http/issues",
-                "source": "https://github.com/rancoud/Http/tree/3.2.0"
+                "source": "https://github.com/rancoud/Http/tree/3.2.2"
             },
-            "time": "2024-01-17T19:37:28+00:00"
+            "time": "2024-03-03T20:42:02+00:00"
         },
         {
             "name": "rancoud/router",
-            "version": "3.1.3",
+            "version": "3.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rancoud/Router.git",
-                "reference": "f2e4d52b8ae7a5f839ae4dd8e2dfabd05b23e406"
+                "reference": "b94332349dc19af624bdf78e18af1a0caa73c257"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rancoud/Router/zipball/f2e4d52b8ae7a5f839ae4dd8e2dfabd05b23e406",
-                "reference": "f2e4d52b8ae7a5f839ae4dd8e2dfabd05b23e406",
+                "url": "https://api.github.com/repos/rancoud/Router/zipball/b94332349dc19af624bdf78e18af1a0caa73c257",
+                "reference": "b94332349dc19af624bdf78e18af1a0caa73c257",
                 "shasum": ""
             },
             "require": {
@@ -147,9 +147,9 @@
             "description": "Router package",
             "support": {
                 "issues": "https://github.com/rancoud/Router/issues",
-                "source": "https://github.com/rancoud/Router/tree/3.1.3"
+                "source": "https://github.com/rancoud/Router/tree/3.1.4"
             },
-            "time": "2024-01-20T18:18:50+00:00"
+            "time": "2024-03-03T21:00:23+00:00"
         }
     ],
     "packages-dev": [
@@ -1333,16 +1333,16 @@
         },
         {
             "name": "rancoud/database",
-            "version": "6.0.8",
+            "version": "6.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rancoud/Database.git",
-                "reference": "716236f7e728cebecb2a10b17fe99d975ac842f7"
+                "reference": "b8eab4676ccfce8cd483cfcc6b0487d57f18aae7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rancoud/Database/zipball/716236f7e728cebecb2a10b17fe99d975ac842f7",
-                "reference": "716236f7e728cebecb2a10b17fe99d975ac842f7",
+                "url": "https://api.github.com/repos/rancoud/Database/zipball/b8eab4676ccfce8cd483cfcc6b0487d57f18aae7",
+                "reference": "b8eab4676ccfce8cd483cfcc6b0487d57f18aae7",
                 "shasum": ""
             },
             "require": {
@@ -1378,22 +1378,22 @@
             "description": "Database package",
             "support": {
                 "issues": "https://github.com/rancoud/Database/issues",
-                "source": "https://github.com/rancoud/Database/tree/6.0.8"
+                "source": "https://github.com/rancoud/Database/tree/6.0.9"
             },
-            "time": "2024-01-20T17:26:47+00:00"
+            "time": "2024-03-03T19:21:31+00:00"
         },
         {
             "name": "rancoud/session",
-            "version": "5.0.5",
+            "version": "5.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rancoud/Session.git",
-                "reference": "1a6218aff0c13c2cc38b1bc5f43f5a9790946259"
+                "reference": "38758dc43e8fcf06a17b1e337bbf9969e3e04183"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rancoud/Session/zipball/1a6218aff0c13c2cc38b1bc5f43f5a9790946259",
-                "reference": "1a6218aff0c13c2cc38b1bc5f43f5a9790946259",
+                "url": "https://api.github.com/repos/rancoud/Session/zipball/38758dc43e8fcf06a17b1e337bbf9969e3e04183",
+                "reference": "38758dc43e8fcf06a17b1e337bbf9969e3e04183",
                 "shasum": ""
             },
             "require": {
@@ -1428,9 +1428,9 @@
             "description": "Session package",
             "support": {
                 "issues": "https://github.com/rancoud/Session/issues",
-                "source": "https://github.com/rancoud/Session/tree/5.0.5"
+                "source": "https://github.com/rancoud/Session/tree/5.0.6"
             },
-            "time": "2024-01-20T17:53:24+00:00"
+            "time": "2024-03-03T20:19:48+00:00"
         },
         {
             "name": "sebastian/cli-parser",


### PR DESCRIPTION
# Description
* bump `rancoud/database` from `6.0.8` to `6.0.9`
* bump `rancoud/environment` from `2.1.9` to `2.1.10`
* bump `rancoud/http` from `3.2.0` to `3.2.2`
* bump `rancoud/router` from `3.1.3` to `3.1.4`
* bump `rancoud/session` from `5.0.5` to `5.0.6`