### PR TITLE
chore: add php 8.5 to tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: PHPUnit
         run: |
-          vendor/bin/phpunit --colors --display-deprecation --coverage-text --coverage-clover coverage/clover.xml
+          vendor/bin/phpunit --colors --display-all-issues --coverage-text --coverage-clover coverage/clover.xml
 
       - name: Upload coverage
         uses: codecov/codecov-action@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,13 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  push:
-    paths-ignore:
-      - '**.md'
   pull_request:
     paths-ignore:
       - '**.md'
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 jobs:
   test:
@@ -26,6 +27,7 @@ jobs:
           - ubuntu-latest
         php-version:
           - '8.4'
+          - '8.5'
 
     steps:
       - name: Checkout
@@ -55,12 +57,13 @@ jobs:
         run: composer install --prefer-dist --no-progress
 
       - name: Lint
+        if: matrix.php-version == '8.4'
         run: |
-          PHP_CS_FIXER_IGNORE_ENV=True vendor/bin/php-cs-fixer fix --diff --dry-run
+          vendor/bin/php-cs-fixer fix --diff --dry-run
 
       - name: PHPUnit
         run: |
-          vendor/bin/phpunit --colors --coverage-text --coverage-clover coverage/clover.xml
+          vendor/bin/phpunit --colors --display-deprecation --coverage-text --coverage-clover coverage/clover.xml
 
       - name: Upload coverage
         uses: codecov/codecov-action@v6

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
             "php-cs-fixer fix -vvv"
         ],
         "test": [
-            "phpunit --colors --coverage-html ./coverage"
+            "phpunit --colors --display-deprecation --coverage-html ./coverage"
         ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
             "php-cs-fixer fix -vvv"
         ],
         "test": [
-            "phpunit --colors --display-deprecation --coverage-html ./coverage"
+            "phpunit --colors --display-all-issues --coverage-html ./coverage"
         ]
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1594,16 +1594,16 @@
         },
         {
             "name": "rancoud/session",
-            "version": "6.2.0",
+            "version": "6.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rancoud/Session.git",
-                "reference": "0952520589497cbf401e26c34d319d150c2a64b6"
+                "reference": "677da0e4c6b0343328f3cb8430df8d2fe99b21c8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rancoud/Session/zipball/0952520589497cbf401e26c34d319d150c2a64b6",
-                "reference": "0952520589497cbf401e26c34d319d150c2a64b6",
+                "url": "https://api.github.com/repos/rancoud/Session/zipball/677da0e4c6b0343328f3cb8430df8d2fe99b21c8",
+                "reference": "677da0e4c6b0343328f3cb8430df8d2fe99b21c8",
                 "shasum": ""
             },
             "require": {
@@ -1637,9 +1637,9 @@
             "description": "Session package",
             "support": {
                 "issues": "https://github.com/rancoud/Session/issues",
-                "source": "https://github.com/rancoud/Session/tree/6.2.0"
+                "source": "https://github.com/rancoud/Session/tree/6.2.1"
             },
-            "time": "2026-03-28T14:28:48+00:00"
+            "time": "2026-05-31T18:21:28+00:00"
         },
         {
             "name": "react/cache",

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "rancoud/environment",
-            "version": "3.0.1",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rancoud/Environment.git",
-                "reference": "565f4fba44f86517d9b024f9441ebbd308625f61"
+                "reference": "bcb1db564234417909aa2e7119102fe987a034b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rancoud/Environment/zipball/565f4fba44f86517d9b024f9441ebbd308625f61",
-                "reference": "565f4fba44f86517d9b024f9441ebbd308625f61",
+                "url": "https://api.github.com/repos/rancoud/Environment/zipball/bcb1db564234417909aa2e7119102fe987a034b3",
+                "reference": "bcb1db564234417909aa2e7119102fe987a034b3",
                 "shasum": ""
             },
             "require": {
@@ -47,22 +47,22 @@
             "description": "Environment package",
             "support": {
                 "issues": "https://github.com/rancoud/Environment/issues",
-                "source": "https://github.com/rancoud/Environment/tree/3.0.1"
+                "source": "https://github.com/rancoud/Environment/tree/3.0.2"
             },
-            "time": "2026-03-15T12:03:48+00:00"
+            "time": "2026-05-31T18:07:50+00:00"
         },
         {
             "name": "rancoud/http",
-            "version": "5.0.1",
+            "version": "5.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rancoud/Http.git",
-                "reference": "3a226fff7aa162129ed04d23b8fc27970c8a6940"
+                "reference": "3e71657659da5cb33f6bff76ec65100c0a0b845a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rancoud/Http/zipball/3a226fff7aa162129ed04d23b8fc27970c8a6940",
-                "reference": "3a226fff7aa162129ed04d23b8fc27970c8a6940",
+                "url": "https://api.github.com/repos/rancoud/Http/zipball/3e71657659da5cb33f6bff76ec65100c0a0b845a",
+                "reference": "3e71657659da5cb33f6bff76ec65100c0a0b845a",
                 "shasum": ""
             },
             "require": {
@@ -99,22 +99,22 @@
             "description": "Http package",
             "support": {
                 "issues": "https://github.com/rancoud/Http/issues",
-                "source": "https://github.com/rancoud/Http/tree/5.0.1"
+                "source": "https://github.com/rancoud/Http/tree/5.0.2"
             },
-            "time": "2026-03-15T12:03:51+00:00"
+            "time": "2026-05-31T18:09:17+00:00"
         },
         {
             "name": "rancoud/router",
-            "version": "5.0.2",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rancoud/Router.git",
-                "reference": "b2ec82c8a5da7e1e81e36cc9797321162f2f76b5"
+                "reference": "c92a73c786ca9cb3d3e86308aa043e2fa4ff1a66"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rancoud/Router/zipball/b2ec82c8a5da7e1e81e36cc9797321162f2f76b5",
-                "reference": "b2ec82c8a5da7e1e81e36cc9797321162f2f76b5",
+                "url": "https://api.github.com/repos/rancoud/Router/zipball/c92a73c786ca9cb3d3e86308aa043e2fa4ff1a66",
+                "reference": "c92a73c786ca9cb3d3e86308aa043e2fa4ff1a66",
                 "shasum": ""
             },
             "require": {
@@ -144,9 +144,9 @@
             "description": "Router package",
             "support": {
                 "issues": "https://github.com/rancoud/Router/issues",
-                "source": "https://github.com/rancoud/Router/tree/5.0.2"
+                "source": "https://github.com/rancoud/Router/tree/5.0.3"
             },
-            "time": "2026-03-28T12:59:22+00:00"
+            "time": "2026-05-31T18:13:25+00:00"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -1544,16 +1544,16 @@
         },
         {
             "name": "rancoud/database",
-            "version": "7.0.1",
+            "version": "7.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rancoud/Database.git",
-                "reference": "13954b99d25834cd1dd34a6f4a95c1692e359a18"
+                "reference": "4ac7ba682256798b6a0a7f236d0517f4a61836ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rancoud/Database/zipball/13954b99d25834cd1dd34a6f4a95c1692e359a18",
-                "reference": "13954b99d25834cd1dd34a6f4a95c1692e359a18",
+                "url": "https://api.github.com/repos/rancoud/Database/zipball/4ac7ba682256798b6a0a7f236d0517f4a61836ba",
+                "reference": "4ac7ba682256798b6a0a7f236d0517f4a61836ba",
                 "shasum": ""
             },
             "require": {
@@ -1588,9 +1588,9 @@
             "description": "Database package",
             "support": {
                 "issues": "https://github.com/rancoud/Database/issues",
-                "source": "https://github.com/rancoud/Database/tree/7.0.1"
+                "source": "https://github.com/rancoud/Database/tree/7.0.2"
             },
-            "time": "2026-03-15T11:54:21+00:00"
+            "time": "2026-05-31T17:54:16+00:00"
         },
         {
             "name": "rancoud/session",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  
Here are some tips for you:  
1. If this PR is still in in Progress, put it in draft.
2. If this PR is introducing a breaking change please prefix with *BREAKING* in PR title.
3. If this PR has any follow up tasks, please prefix with *TODO* and describe follow up task.
4. When PR is ready to be reviewed, please tag rancoud as a sole reviewer.
-->
# Description
* add php 8.5 to test workflow
* avoid double run on github action
* add `--display-all-issues` on phpunit command
* remove lint action on php 8.5
* remove `PHP_CS_FIXER_IGNORE_ENV=True` for lint
* update dependency `rancoud/environment` from 3.0.1 to 3.0.2
* update dependency `rancoud/http` from 5.0.1 to 5.0.2
* update dependency `rancoud/router` from 5.0.2 to 5.0.3
* update dependency `rancoud/database` from 7.0.1 to 7.0.2
* update dependency `rancoud/session` from 6.2.0 to 6.2.1